### PR TITLE
added support to specify lirc socket

### DIFF
--- a/lib/irsend.js
+++ b/lib/irsend.js
@@ -2,7 +2,19 @@ var exec = require('child_process').exec;
 
 exports = module.exports = IRSend;
 
-function IRSend () {};
+function IRSend () {
+  this.command = 'irsend';
+};
+
+// In some cases the default lirc socket does not work
+// More info at http://wiki.openelec.tv/index.php?title=Guide_to_Lirc_IR_Blasting
+IRSend.prototype.setSocket = function(socket) {
+  if(socket) {
+    this.command = 'irsend -d ' + socket;
+  } else {
+    this.command = 'irsend';
+  }
+};
 
 IRSend.prototype.list = function(remote, code, callback) {
   var command = this._list(remote, code);
@@ -39,7 +51,7 @@ IRSend.prototype._list = function(remote, code) {
   if (!remote) remote = '';
   if (!code) code = '';
 
-  return 'irsend LIST "' + remote + '" "' + code + '"';
+  return this.command + ' LIST "' + remote + '" "' + code + '"';
 };
 
 IRSend.prototype._send_once = function(remote, code) {
@@ -57,21 +69,21 @@ IRSend.prototype._send_once = function(remote, code) {
     code = code.substr(1, code.length-2);
   }
 
-  return 'irsend SEND_ONCE "' + remote + '" "' + code + '"';
+  return this.command + ' SEND_ONCE "' + remote + '" "' + code + '"';
 };
 
 IRSend.prototype._send_start = function(remote, code) {
   if (!remote) remote = '';
   if (!code) code = '';
 
-  return 'irsend SEND_START "' + remote + '" "' + code + '"';
+  return this.command + ' SEND_START "' + remote + '" "' + code + '"';
 };
 
 IRSend.prototype._send_stop = function(remote, code) {
   if (!remote) remote = '';
   if (!code) code = '';
 
-  return 'irsend SEND_STOP "' + remote + '" "' + code + '"';
+  return this.command + ' SEND_STOP "' + remote + '" "' + code + '"';
 };
 
 IRSend.prototype._set_transmitters = function(transmitters) {
@@ -85,9 +97,9 @@ IRSend.prototype._set_transmitters = function(transmitters) {
     transmitters = newTransmitters.trim();
   }
 
-  return 'irsend SET_TRANSMITTERS ' + transmitters;
+  return this.command + ' SET_TRANSMITTERS ' + transmitters;
 };
 
 IRSend.prototype._simulate = function(code) {
-  return 'irsend SIMULATE "' + code + '"';
+  return this.command + ' SIMULATE "' + code + '"';
 };

--- a/lib/lirc_node.js
+++ b/lib/lirc_node.js
@@ -9,6 +9,11 @@ exports.addListener = irreceive.addListener.bind(irreceive);
 exports.on = exports.addListener;
 exports.removeListener = irreceive.removeListener.bind(irreceive);
 
+// In some cases the default lirc socket does not work
+// More info at http://wiki.openelec.tv/index.php?title=Guide_to_Lirc_IR_Blasting
+exports.setSocket = function(socket) {
+  exports.irsend.setSocket(socket);
+}
 
 exports.init = function(callback) {
   exports.irsend.list('', '', irsendCallback);


### PR DESCRIPTION
in some cases the default lirc socket does not work, as seen at http://wiki.openelec.tv/index.php?title=Guide_to_Lirc_IR_Blasting

I have added an option to specify the target socket, so it includes the lirc socket in the irsend commands.

Needed this solution for my raspberry pi zero osmc setup.