### PR TITLE
Bugfix: call callback after fetching remote commands

### DIFF
--- a/lib/lirc_node.js
+++ b/lib/lirc_node.js
@@ -38,21 +38,23 @@ exports._populateRemotes = function(error, stdout, stderr) {
   });
 };
 
+function fetchCommandsForRemote(callback, remote){
+  exports.irsend.list(remote, '', function(error, stdout, stderr) {
+    exports._populateRemoteCommands(remote, error, stdout, stderr);
+    callback();
+  });
+}
+
 exports._populateCommands = function(callback) {
   var openForks = 0;
   var collector = function () {
     if (--openForks <= 0) {
-        if (callback) callback();
+      if (callback) callback();
     }
   };
   for (var remote in exports.remotes) {
-    (function(remote) {
-      openForks++;
-      exports.irsend.list(remote, '', function(error, stdout, stderr) {
-        exports._populateRemoteCommands(remote, error, stdout, stderr);
-        collector();
-      });
-    })(remote);
+    openForks++;
+    fetchCommandsForRemote(collector, remote);
   }
 };
 

--- a/lib/lirc_node.js
+++ b/lib/lirc_node.js
@@ -20,8 +20,7 @@ exports.init = function(callback) {
 
   function irsendCallback(error, stdout, stderr) {
     exports._populateRemotes(error, stdout, stderr);
-    exports._populateCommands();
-    if (callback) callback();
+    exports._populateCommands(callback);
   }
 
   return true;
@@ -39,11 +38,19 @@ exports._populateRemotes = function(error, stdout, stderr) {
   });
 };
 
-exports._populateCommands = function() {
+exports._populateCommands = function(callback) {
+  var openForks = 0;
+  var collector = function () {
+    if (--openForks <= 0) {
+        if (callback) callback();
+    }
+  };
   for (var remote in exports.remotes) {
     (function(remote) {
+      openForks++;
       exports.irsend.list(remote, '', function(error, stdout, stderr) {
         exports._populateRemoteCommands(remote, error, stdout, stderr);
+        collector();
       });
     })(remote);
   }


### PR DESCRIPTION
The init callback has been called directly after fetching the lirc remotes. The commands of these were not available then. Fixed by collecting the execs fetching the remote commands.

Since the involved methods solely rely on output of the executed commands, i see no reasonable way to implement a test which validates the timing.
