### PR TITLE
Fix issue #11.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/lib/irreceive.js
+++ b/lib/irreceive.js
@@ -126,7 +126,7 @@ IRReceive.prototype.addListener = function() {
  */
 IRReceive.prototype.removeListener = function(listenerId) {
 
-    this.callbacks[listenerId] = null;
+    delete this.callbacks[listenerId];
     this.numCallbacks--;
 
     if(this.numCallbacks <= 0 && this.listening) {


### PR DESCRIPTION
This fixing #11.

When removing a listener, the callback gets replaced by null. But when looping through the callbacks, it tries to read the property throttle of null. As far as I know, this is a bug and should be fixed.
