### PR TITLE
Fixed the callback for init, now the remotes are ready before callback

### DIFF
--- a/lib/lirc_node.js
+++ b/lib/lirc_node.js
@@ -20,8 +20,7 @@ exports.init = function(callback) {
 
   function irsendCallback(error, stdout, stderr) {
     exports._populateRemotes(error, stdout, stderr);
-    exports._populateCommands();
-    if (callback) callback();
+    exports._populateCommands(callback);
   }
 
   return true;
@@ -39,14 +38,21 @@ exports._populateRemotes = function(error, stdout, stderr) {
   });
 };
 
-exports._populateCommands = function() {
-  for (var remote in exports.remotes) {
-    (function(remote) {
-      exports.irsend.list(remote, '', function(error, stdout, stderr) {
-        exports._populateRemoteCommands(remote, error, stdout, stderr);
-      });
-    })(remote);
-  }
+exports._populateCommands = function(callback) {
+    var remoteQ = [];
+    for (var remote in exports.remotes) {
+        remoteQ.push(remote);
+    }
+    populate = function(remoteQ) {
+        if (remoteQ.length > 0) {
+            var remote = remoteQ.pop();
+            exports.irsend.list(remote, '', function(error, stdout, stderr) {
+                exports._populateRemoteCommands(remote, error, stdout, stderr);
+                populate(remoteQ);
+            });
+        } else if (typeof callback === "function") callback();
+    }
+    populate(remoteQ);
 };
 
 exports._populateRemoteCommands = function(remote, error, stdout, stderr) {

--- a/lib/lirc_node.js
+++ b/lib/lirc_node.js
@@ -43,7 +43,7 @@ exports._populateCommands = function(callback) {
     for (var remote in exports.remotes) {
         remoteQ.push(remote);
     }
-    populate = function(remoteQ) {
+    var populate = function(remoteQ) {
         if (remoteQ.length > 0) {
             var remote = remoteQ.pop();
             exports.irsend.list(remote, '', function(error, stdout, stderr) {


### PR DESCRIPTION
Before this change the callback for init wasn't actually being called after init finished. 
`lirc = require("lirc_node");
lirc.init(function(){
console.log(lirc.remotes);
});`
This wouldn't work before because lirc.remotes wouldn't be ready yet but, callbacks are supposed to be called after a task is finished. 